### PR TITLE
file changes for cookie cutter folder

### DIFF
--- a/{{cookiecutter.package_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.package_name}}/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 repos:
 -   repo: git@github.com:Yelp/detect-secrets
-    rev: v0.14.3
+    rev: v1.0.3
     hooks:
     -   id: detect-secrets
-        args: ['--baseline', '.secrets.baseline', '--custom-plugins', 'detect-secrets-plugins/', '--word-list', '.secrets.ignore']
+        args: ['--baseline', '.secrets.baseline', '--plugin','detect-secrets-plugins/occ_regex.py', '--word-list', '.secrets.ignore']
         additional_dependencies: ['pyahocorasick']
         exclude: .secrets.ignore
 -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/{{cookiecutter.package_name}}/detect-secrets-plugins/occ_regex.py
+++ b/{{cookiecutter.package_name}}/detect-secrets-plugins/occ_regex.py
@@ -1,16 +1,11 @@
 import re
 
-from detect_secrets.plugins.base import classproperty
 from detect_secrets.plugins.base import RegexBasedDetector
-
 
 class OCCRegexDetector(RegexBasedDetector):
     """Scans for common secrets in OCC."""
     secret_type = 'OCC REGEX'
 
-    @classproperty
-    def disable_flag_text(cls):
-        return 'no-occ-regex-scan'
 
     denylist = (
         re.compile(


### PR DESCRIPTION
The following flags changed for version update from 0.14.3 to 1.0.3 for cookie cutter folder

--custom-plugins to -p or --plugin
--no-base64-string-scan to --disable-plugin Base64HighEntropyString
--no-hex-string-scan to --disable-plugin HexHighEntropyString
in our custom plugin, detect_secerts_plugin/occ_regex.py

removed old object classproperty